### PR TITLE
brh.xml missing closing </characters> tag

### DIFF
--- a/sldr/b/brh.xml
+++ b/sldr/b/brh.xml
@@ -32,6 +32,7 @@
 		<exemplarCharacters type="punctuation">[، ; \: ! ۔ ' ‘ ( ) \[ \] \{ \} /]</exemplarCharacters>
 		<exemplarCharacters type="index">[ء آ أ ؤ ئ ا ب پ ة ت ث ج چ ح خ د ذ ر ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل ڷ م ن ں ه و ی ]</exemplarCharacters>
 		<exemplarCharacters type="numbers">[\u200E \- ‑ , ٫ ٬ . % ٪ ‰ ؉ + − 0۰ 1۱ 2۲ 3۳ 4۴ 5۵ 6۶ 7۷ 8۸ 9۹]</exemplarCharacters>
+	</characters>
 	<special>
 		<sil:external-resources>
 			<sil:font name="Noto Sans Arabic" types="ui">


### PR DESCRIPTION
Got the following error when trying to parse the file using `lxml`:
```
lxml.etree.XMLSyntaxError: Opening and ending tag mismatch: characters line 29 and ldml, line 45, column 8
```
This PR adds a closing tag for the `characters` tag on line 35.