### PR TITLE
[gel] Replace ʻ 02BB by ' 0027

### DIFF
--- a/sldr/g/gel.xml
+++ b/sldr/g/gel.xml
@@ -20,7 +20,7 @@
 		</special>
 	</localeDisplayNames>
 	<characters>
-		<exemplarCharacters>[a {à} {á} {a̱} {à̱} {á̱} b c d e {è} {é} {e̱} {è̱} {é̱} f g {gb} h i {ì} {í} j k {kp} l m n {ń} o {ò} {ó} {o̱} {ò̱} {ó̱} p r s t u {ù} {ú} w y z ʻ]</exemplarCharacters>
+		<exemplarCharacters>[a {à} {á} {a̱} {à̱} {á̱} b c d e {è} {é} {e̱} {è̱} {é̱} f g {gb} h i {ì} {í} j k {kp} l m n {ń} o {ò} {ó} {o̱} {ò̱} {ó̱} p r s t u {ù} {ú} w y z ']</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[q x]</exemplarCharacters>
 	</characters>
 	<special>


### PR DESCRIPTION
This commit replaces ʻ 02BB by ' 0027 in the ut-Ma'in exemplarCharacters based on references and corpus.

R. D. Smith (2007)[1], p. 1:
> The current u̱t-Ma'in orthography uses the underlined “u̱” to represent
> the near close-mid central vowel [ɘ].
> The glottal stop [ʔ] is indicated by the apostrophe “ ' ”.

R. D. Smith Paterson (2019)[2], p. 46, table 17 "U̠t-Ma'in Phones and U̠t-Ma'in orthographic symbols" also shows the apostrophe “ ' ” for the glottal stop.

Wycliffe Bible Translators with Ut-Ma'in Language and Translation Committee (2024)[3] uses U+0027 as well.

[1] R. D. Smith (2007), The noun class system of u̱t-Ma'in, a West Kainji language of Nigeria, https://commons.und.edu/theses/4476/
[2] R. D. Smith Paterson (2019), Nominalization and predication in U̱t‑Maꞌin, http://hdl.handle.net/1794/25259
[3] Wycliffe Bible Translators with Ut-Ma'in Language and Translation Committee (2024), ut-Mai'n Scripture portions, https://www.bible.com/bible/3989