### PR TITLE
[gby] Remove ʻ 02BB from index

### DIFF
--- a/sldr/g/gby.xml
+++ b/sldr/g/gby.xml
@@ -22,7 +22,7 @@
 	<characters>
 		<exemplarCharacters>[a b c d e f g h i j k l m n o p r s t u w y z ɓ ɗ ʻ \u0300 \u0301 \u0302 \u030c]</exemplarCharacters>
 		<exemplarCharacters type="auxiliary">[q x]</exemplarCharacters>
-		<exemplarCharacters type="index" draft="generated">[A B C D E F G H I J K L M N O P R S T U W Y Z Ɓ Ɗ ʻ]</exemplarCharacters>
+		<exemplarCharacters type="index" draft="generated">[A B C D E F G H I J K L M N O P R S T U W Y Z Ɓ Ɗ]</exemplarCharacters>
 		<exemplarCharacters type="punctuation" draft="generated">[! ( ) , \- . \: ; ? \[ \]]</exemplarCharacters>
 	</characters>
 	<special>


### PR DESCRIPTION
Gbari [gby] orthography uses the apostrophe, or sometimes turned comma, for the elision of prefix e- in nominalization.

In some works U+02BB MODIFIER LETTER TURNED COMMA is used, for example in Harley & Rosendall 2022 [1] or in Bible for Children translations [2]. [Edit: At first this didn’t seem consistent as some other apostrophe characters are used as well, but given additional examples found, it’s de facto used if not the norm. However, it is definitely not a letter for the index exemplar.]

In one of the Bible for Children translations [3], the elision is represented with ‘ U+2018 LEFT SINGLE QUOTATION MARK on the title page of the PDF and with ʻ U+02BB in the rest of the document but the nested opening quote is also represented with ʻ U+02BB:  “Ke Zafnu de mula nyigo yi é gna ɗye, ʻZhi!’ Ke zanɗye wa wo ɗye ʻZhi!’ Ke zanɗye nuwna miwnu wo wo nya wo zhi. Ke zanɗye a ɓawo nya, wo go nuwna wyewye nyi tantaki.”

The 2023 digital version of the 1956 Gbari New Testament [4], albeit using an old orthography, uses ' U+0027 APOSTROPHE.

Looking at some documents, it’s not clear if ʻ U+02BB or ' U+0027 or ‘ U+2018 should be in the base characters exemplar as it is not listed as a letter from the Philip & Seshi 2004 orthography [5] in Alerechi & Chiemezie 2019 [6]. But the turned comma shape ʻ U+02BB or ‘ U+2018 is used in the orthography reference A. N. Philip, *How to read and write Gbari*, 2020 [7] so it makes sense to have it in the base character exemplar, but not in the index character exemplar.

Philip 2020 does mention or shows acute, grave, circumflex, caron being used for tones on vowels in certain words.

[1] Matthew Harley, Patrick Rosendall, Word break conflicts and elision in Gbari nominalizations, Annual Conference on African Linguistics, University of San Diego, 7-9 April 2022, 2022, https://www.sil.org/resources/archives/96517
[2] Baibulu Aɓeta, https://bibleforchildren.org/languages/gbagyi_east/stories.php
[1] Sanɗye Tswashe Wa Snu Ayna Khikhiri Ge Nya https://bibleforchildren.org/PDFs/gbagyi_east/01_When_God_Made_Everything_Gbagyi_east.pdf
[3] Edward Hughes et al., Shenzhi, Tswashe ‘Pyi Mari, Aɓyanƙe Baibulu = Bible for Children, 2022, https://bibleforchildren.org/PDFs/gbagyi_east/60_Heaven_Gods_Beautiful_Home_Gbagyi_east.pdf
[4] Gbari New Testament (Hay Version) , 1956, https://bibliamundi.com/wp-content/uploads/2023/09/Gbari-Bible-New-Testament.pdf
[5] A. N. Philip et N. Sheshi, The Gbari orthography, Minna, Gbari Language Development Committee, 2004
[6] R. I. Alerechi, O. A. Chiemezie, ”The Syllable Structure of Gbari“, The International Journal of Humanities & Social Studies, vol. 7, no. 12, 2019, 215-225, https://www.internationaljournalcorner.com/index.php/theijhss/article/view/150668
[7] A. N. Philip, *How to read and write Gbari*, 2020